### PR TITLE
Add versions to all dependencies

### DIFF
--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -1,7 +1,7 @@
-ldap3
-PyMySQL
-sendgrid
-flask
-markdown
-paramiko
-typing
+ldap3==2.4.1
+PyMySQL==0.8.0
+sendgrid==5.3.0
+Flask==0.12.2
+Markdown==2.6.11
+paramiko==2.4.0
+typing==3.6.4


### PR DESCRIPTION
Pinning versions means less goes wrong later because a dependency updated or an API broke.

Got the versions installed from the docker image running on Leela:

```bash
$ docker exec -it netsocadmin bash
root@<redacted>:/netsocadmin/webapp# pip freeze
asn1crypto==0.24.0
bcrypt==3.1.4
certifi==2018.1.18
cffi==1.11.4
chardet==3.0.4
click==6.7
cryptography==2.1.4
Flask==0.12.2
idna==2.6
itsdangerous==0.24
Jinja2==2.10
ldap3==2.4.1
Markdown==2.6.11
MarkupSafe==1.0
paramiko==2.4.0
pyasn1==0.4.2
pycparser==2.18
PyMySQL==0.8.0
PyNaCl==1.2.1
python-http-client==3.0.0
requests==2.18.4
sendgrid==5.3.0
six==1.11.0
subprocess.run==0.0.8
typing==3.6.4
urllib3==1.22
Werkzeug==0.14.1
wget==3.2
-e git+https://github.com/UCCNetworkingSociety/netsocadmin2.git@897661c818f6403368a76454202474475f3511a2#egg=wordpress_installer&subdirectory=wordpress_installer
```